### PR TITLE
fix: missing dep. @codemirror/autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {
+    "@codemirror/autocomplete": "^6.9.1",
     "@codemirror/language": "https://github.com/lishid/cm-language",
     "@codemirror/state": "^6.1.0",
     "@codemirror/view": "^6.1.0",


### PR DESCRIPTION
> **Important**
> Manually merged into https://github.com/GamerGirlandCo/obsidian-fountain-revived/pull/9.

## Overview

Add what seems to be a missing dependency, `@codemirror/autocomplete`.

<details><summary>To avoid error on <code>yarn run build</code> "Could not resolve '@codemirror/autocomplete' (…)"</summary>

```log
➜  obsidian-fountain-revived-wesleyboar git:(main) yarn run build
yarn run v1.22.19
$ export NODE_ENV=production && obsidian-plugin build src/main.ts -e esbuild.config.js

  main.js  97.2kb

 > src/extensions.ts:8:85: error: Could not resolve "@codemirror/autocomplete" (mark it as external to exclude it from the bundle)
    8 │ import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from "@codemirror/autocomplete";
      ╵                                                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~

    Error: Build failed with 1 error:
    src/extensions.ts:8:85: error: Could not resolve "@codemirror/autocomplete" (mark it as external to exclude it from the bundle)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

## Changes

- **added** dependency `@codemirror/autocomplete`

## Testing

1. Clone https://github.com/wesleyboar/obsidian-fountain-revived into `.obsidian/plugins/`.
2. Navigate into the directory.
3. `yarn install`
4. `yarn run build`
5. Verify **no** error about `@codemirror/autocomplete`.