### PR TITLE
fix: include stylesheet in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet build src/styles.css src/main.ts -e esbuild.config.js",
+    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet src/styles.css build src/main.ts -e esbuild.config.js",
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet src/styles.css build src/main.ts -e esbuild.config.js",
+    "build": "export NODE_ENV=production && obsidian-plugin build src/main.ts --with-stylesheet src/styles.css -e esbuild.config.js",
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin build src/main.ts -e esbuild.config.js",
+    "build": "export NODE_ENV=production && obsidian-plugin build --with-stylesheet src/styles.css src/main.ts -e esbuild.config.js",
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin build --with-stylesheet src/styles.css src/main.ts -e esbuild.config.js",
+    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet build src/styles.css src/main.ts -e esbuild.config.js",
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {


### PR DESCRIPTION
> **Important**
> Manually merged into https://github.com/GamerGirlandCo/obsidian-fountain-revived/pull/9.

## Overview

The `yarn build` (when successful[^1]) did not add `styles.css` to `dist/` for me. This change made it do so.

Reference:
- [obsidian-plugin-cli `README.md`](https://github.com/obsidian-tools/obsidian-tools/tree/obsidian-plugin-cli%400.8.3/packages/obsidian-plugin-cli#obsidian-plugin-build-entrypoint)
- [obsidian-plugin-cli `package.json` template](https://github.com/obsidian-tools/obsidian-tools/blob/obsidian-plugin-cli%400.8.3/packages/create-obsidian-plugin/src/templates/package.json.ejs#L8)

## Related

- included in #5

## Changes

- **added** argument to `package.json` `build` script

## Testing

<details><summary>Pre-Test Setup I Did</summary>

1. `git remote add upstream git@github.com:GamerGirlandCo/obsidian-fountain-revived.git`
2. `git fetch upstream`

</details>
<details open><summary>Post-Setup Test Steps</summary>

1. `git checkout 0.1.0`
2. `yarn install`
3. `yarn add @codemirror/autocomplete`[^1]
4. `yarn build`
5. ❌ The `dist/` folder does **not** have `styles.css`.
6. Check out this PR's branch.
7. `yarn build`
8. ✅ The `dist/` folder **has** `styles.css`.

</details>

[^1]: See #2.