### PR TITLE
fix: dev script not using obsidian-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin build src/main.ts -e esbuild.config.js",
-    "dev": "node esbuild.config.js"
+    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet src/styles.css build src/main.ts -e esbuild.config.js",
+    "dev": "export NODE_ENV=development && obsidian-plugin dev --with-stylesheet src/styles.css src/main.ts -e esbuild.config.js"
   },
   "devDependencies": {
     "@codemirror/language": "https://github.com/lishid/cm-language",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin --with-stylesheet src/styles.css build src/main.ts -e esbuild.config.js",
-    "dev": "export NODE_ENV=development && obsidian-plugin --with-stylesheet src/styles.css dev src/main.ts -e esbuild.config.js"
+    "build": "export NODE_ENV=production && obsidian-plugin build src/main.ts --with-stylesheet src/styles.css -e esbuild.config.js",
+    "dev": "export NODE_ENV=development && obsidian-plugin dev src/main.ts --with-stylesheet src/styles.css -e esbuild.config.js"
   },
   "devDependencies": {
     "@codemirror/language": "https://github.com/lishid/cm-language",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "export NODE_ENV=production && obsidian-plugin build src/main.ts -e esbuild.config.js",
+    "build": "export NODE_ENV=production && obsidian-plugin build --with-stylesheet src/styles.css src/main.ts -e esbuild.config.js",
     "dev": "node esbuild.config.js"
   },
   "devDependencies": {


### PR DESCRIPTION
> **Important**
> Manually merged into https://github.com/GamerGirlandCo/obsidian-fountain-revived/pull/9.

## Overview

If `build` script uses `obsidian-plugin`, then why not the `dev script` too?

## Related

- includes #4

## Changes

- **changed** `package.json` `dev` script to be similar to `build` script
- **added** argument to `package.json` `build` script

## Testing

### Terminal A

1. `yarn install`
2. `yarn add @codemirror/autocomplete`[^1]
3. `yarn dev`
4. "Select the vault to develop in" (as instructed by the CLI).

### Terminal B

5. `ls -la __VAULT_DIR__/.obsidian/plugins/obsidian-fountain-revived`
    <sup>(where `__VAULT_DIR__` is the path to the vault you chose in step 4)</sup>
6. Verify vault has dist assets: `main.js`, `manifest.json`, `styles.css`.