### PR TITLE
fix: fonts (redundancy, missing fallback, incomplete compatibility)

### DIFF
--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -14,7 +14,7 @@ import { ftn } from "./lang-fountain";
 const theme = EditorView.theme({
 	".cm-line": {
 		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important"
+		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', Courier, monospace !important"
 	},
 
 	".cm-foldGutter": {

--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -14,7 +14,7 @@ import { ftn } from "./lang-fountain";
 const theme = EditorView.theme({
 	".cm-line": {
 		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', Courier, monospace !important"
+		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', Courier, monospace"
 	},
 
 	".cm-foldGutter": {

--- a/src/fountain-view.ts
+++ b/src/fountain-view.ts
@@ -13,8 +13,7 @@ import { ftn } from "./lang-fountain";
 
 const theme = EditorView.theme({
 	".cm-line": {
-		caretColor: "var(--text-normal)",
-		"fontFamily": "'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', Courier, monospace"
+		caretColor: "var(--text-normal)"
 	},
 
 	".cm-foldGutter": {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,13 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', 'Courier', monospace !important;
-}
-.is-text-garbled [data-type="fountain"] .cm-scroller,
-.is-text-garbled [data-type="fountain"] *.cm-line,
-.is-text-garbled [data-type="fountain"] .view-content .cm-editor {
-	font-family: 'Flow Circular', sans-serif !important;
-	line-height: 1.45em !important;
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', 'Courier', monospace;
 }
 [data-type="fountain"] .view-content .cm-editor::selection, 
 [data-type="fountain"] .cm-line::selection {

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,7 +22,7 @@
 [data-type="fountain"] .cm-line,
 [data-type="fountain"] .view-content .cm-editor {
 	font-size: 12pt;
-	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime' !important;
+	font-family: 'Courier Final Draft', 'Courier Screenplay', 'Courier Prime', 'Courier', monospace !important;
 }
 .is-text-garbled [data-type="fountain"] .cm-scroller,
 .is-text-garbled [data-type="fountain"] *.cm-line,


### PR DESCRIPTION
## Overview / Changes

1. Font loads for users without preferred Courier fonts.
2. Plugin is still compatible with https://github.com/kurakart/garble-text.
3. Hover on garbled text removes garble.
4. No redundant font CSS.

## Testing & Notes

- https://github.com/wesleyboar/obsidian-fountain-revived/pull/6
- https://github.com/wesleyboar/obsidian-fountain-revived/pull/5
- https://github.com/wesleyboar/obsidian-fountain-revived/pull/7

## UI

<details><summary>before</summary>

https://github.com/GamerGirlandCo/obsidian-fountain-revived/assets/62723358/21fbfab2-e283-481d-8480-b82a601c0bdc

</details>
<details open><summary>after</summary>

https://github.com/GamerGirlandCo/obsidian-fountain-revived/assets/62723358/6a7aa39a-301c-40ba-a344-c56ed5f60c3f

</details>